### PR TITLE
Attempt to fix the Snippet in Google Search

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     />
     <meta
       name="description"
-      content="Remove objects, people, text and defects from any picture for free. Create a clean background for a product picture 📸, re-design any items 👠, fill up some missing space for a youtube thumbnail 🎬, You can use it to iron your shirts 👕...etc!"
+      content="Remove unwanted objects, people, text and defects from any picture for free."
     />
 
     <!-- Social -->
@@ -84,13 +84,10 @@
           will help the algorithm create the best results.
         </p>
 
-        <h2 itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">How to remove an object from a photo?</h2>
+        <h2 itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">How to remove an unwanted object from a photo?</h2>
         <p itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
-          You don't need photoshop to remove an object from a photo. Use the
-          biggest
-          <a href="https://cleanup.pictures">cleanup.pictures</a> brush, and
-          cover the full object. The brush should cover the full object. it is
-          better to overflow to be sure that the whole object is covered.
+          <a href="https://cleanup.pictures">cleanup.pictures</a> brush is a spectacular tool to remove unwanted objects.
+The A.I. algorithm will reconstruct what was behind the object in just one click. Be sure that the whole thing is covered to remove it entirely.
         </p>
 
         <h2 itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">How to remove text or watermarks from an image?</h2>


### PR DESCRIPTION
The snippet was:
You don't need photoshop to remove an object from a photo. Use the biggest cleanup .pictures
brush, and cover the full object. The brush should cover the ...