### PR TITLE
Add the price in the how to

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -117,6 +117,14 @@ The A.I. algorithm will reconstruct what was behind the object in just one click
           exported by Cleanup.pictures.
         </p>
 
+        <h2 itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">How much Cleanup.pictures cost?</h2>
+        <p itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          Cleanup.Picture is 100% free unless you need to process hi-resolution images.
+          The price is $5 per month or $48 per year for processing HD images of any size. (BUT ONLY $24 UNTIL FEB 15).
+          The trial allows testing the HD quality for free.
+          To ease the edition, you'll be able to zoom into an image.
+        </p>
+        
         <h2 itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">How to remove blemish or wrinkles?</h2>
         <p itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
           You can remove blemishes or wrinkles from a photo using the CleanUp brush. Like


### PR DESCRIPTION
 Cleanup.Picture is 100% free unless you need to process hi-resolution images.
The price is $5 per month or $48 per year for processing HD images of any size. (BUT ONLY $24 UNTIL FEB 15).
The trial allows testing the HD quality for free.
To ease the edition, you'll be able to zoom into an image.