### PR TITLE
Display the price as $2 per month instead of $5

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -441,7 +441,7 @@
               <p class="text-center mb-12 bg-primary px-4 py-1 rounded-full">
                 Pro
               </p>
-              <p class="price font-varent">5 <span>per month</span></p>
+              <p class="price font-varent">2 <span>starting from</span></p>
               <ul class="sm:list-disc">
                 <li>Unlimited images</li>
                 <li>Unlimited resolution</li>
@@ -563,7 +563,7 @@
                 or
                 <span
                   class="bg-primary px-2 py-1 rounded-full whitespace-nowrap"
-                  >$48 per year</span
+                  >$48 per year ($4 per month)</span
                 >
                 for processing images of any size. The trial allows testing the
                 HD quality for free. To ease the edition, you'll be able to zoom


### PR DESCRIPTION
Issue:
The main price on display is $5, while the most interesting price for user is $2